### PR TITLE
ci(git-auto-commit): added forked action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -160,13 +160,24 @@ jobs:
       #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
       #     git_user_signingkey: true
       #     git_commit_gpgsign: true
-
-      - name: Git tag
-        run: |
-          git config --local user.name github-actions[bot] #${{ steps.import-gpg.outputs.name }}
-          git config --local user.email github-actions[bot]@zmynx.users.noreply.github.com # ${{ steps.import-gpg.outputs.email }}
-          git tag ${{ needs.package.outputs.release_version }} -m "Release v${{ needs.package.outputs.release_version }}"
-          git push origin ${{ needs.package.outputs.release_version }}
+      
+      - uses: zmynx/git-auto-commit-action@master
+        with:
+          git_tag_only: true
+          commit_message: Release v${{ needs.package.outputs.release_version }}
+          branch: main
+          repository: .
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@zmynx.users.noreply.github.com
+          commit_author: Author <actions@github.com> # defaults to "username <username@users.noreply.github.com>", where "username" belongs to the author of the commit that triggered the run
+          tagging_message: ${{ needs.package.outputs.release_version }}
+          
+      # - name: Git tag
+      #   run: |
+      #     git config --local user.name github-actions[bot] #${{ steps.import-gpg.outputs.name }}
+      #     git config --local user.email github-actions[bot]@zmynx.users.noreply.github.com # ${{ steps.import-gpg.outputs.email }}
+      #     git tag ${{ needs.package.outputs.release_version }} -m "Release v${{ needs.package.outputs.release_version }}"
+      #     git push origin ${{ needs.package.outputs.release_version }}
 
       #############################################
       # PODMAN w/ Cosign


### PR DESCRIPTION
### **User description**
Using a fork version of the `git-auto-commit-action` that hold the ability to push tag, without performing and commit.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Replaced manual Git tag creation with `git-auto-commit-action`.

- Configured the forked action to push tags only.

- Improved workflow maintainability and reduced manual configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cd.yaml</strong><dd><code>Replace manual Git tagging with automated action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cd.yaml

<li>Replaced manual Git tag creation with <code>git-auto-commit-action</code>.<br> <li> Configured action to push tags without committing.<br> <li> Added parameters for user details and tagging message.<br> <li> Commented out the previous manual Git tag creation steps.


</details>


  </td>
  <td><a href="https://github.com/zmynx/aws-lambda-calculator/pull/74/files#diff-7820634de9167dbbf6a1ab9e9c02aab3b8b0ca512494aca230074fd13f630ade">+18/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>