### PR TITLE
fix: potential fix for code scanning alert no. 230

### DIFF
--- a/aws-lambda-calculator/src/aws_lambda_calculator/calculator.py
+++ b/aws-lambda-calculator/src/aws_lambda_calculator/calculator.py
@@ -100,6 +100,7 @@ def unit_conversion_ephemeral_storage(
             return ephemeral_storage_mb
         case _:
             raise ValueError(f"Unknown storage unit: {storage_unit}")
+    return None
 
 
 def calculate_tiered_cost(


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/zmynx/aws-lambda-calculator/security/code-scanning/230](https://github.com/zmynx/aws-lambda-calculator/security/code-scanning/230)

To fix this problem, we should add an explicit return statement at the end of the `unit_conversion_ephemeral_storage` function so that, if execution were ever to reach the end of the function, it would return a consistent value (usually `None`). This explicitness improves readability, signals intent, and satisfies static analysis. The best practice is to use `return None` at the end of the function, after the existing match block. Only the function `unit_conversion_ephemeral_storage` in `aws-lambda-calculator/src/aws_lambda_calculator/calculator.py` needs to be updated, with `return None` inserted at the end, preserving code structure and behaviour.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit `return None` to fix code scanning alert

- Resolve mixed explicit/implicit returns in function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["unit_conversion_ephemeral_storage function"] --> B["match statement with explicit returns"]
  B --> C["Add explicit return None"]
  C --> D["Fixed code scanning alert"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calculator.py</strong><dd><code>Add explicit return statement to function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aws-lambda-calculator/src/aws_lambda_calculator/calculator.py

<ul><li>Add explicit <code>return None</code> statement at end of <br><code>unit_conversion_ephemeral_storage</code> function<br> <li> Fix code scanning alert about mixed explicit/implicit returns</ul>


</details>


  </td>
  <td><a href="https://github.com/zmynx/aws-lambda-calculator/pull/194/files#diff-c7b3b1a27a7165817aff285d58489a9f20b459067de13a9af630ba767b13f0bb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

