### PR TITLE
Potential fix for code scanning alert no. 371: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-jsons.yaml
+++ b/.github/workflows/generate-jsons.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   generate-json:
+    permissions:
+      contents: read
     timeout-minutes: 15
     name: generate-json (${{ matrix.region_code }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zmynx/aws-lambda-calculator/security/code-scanning/371](https://github.com/zmynx/aws-lambda-calculator/security/code-scanning/371)

In general, the fix is to explicitly declare a minimal `permissions` block for the job or workflow so the automatically provided `GITHUB_TOKEN` has only the scopes needed. For this workflow, the `generate-json` job only checks out code, installs dependencies, runs Python/Playwright, and uploads artifacts; it does not need to write to the repository or interact with issues, PRs, or other resources. Therefore, `contents: read` is sufficient for that job.

The best targeted fix without changing existing functionality is:
- Add a `permissions` block to the `generate-json` job, directly under the job definition, configured as:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the `commit-and-push` job’s `permissions: write-all` unchanged because it does need broad write scopes to push commits (and it is already explicitly restricted at the job level).

Concretely, in `.github/workflows/generate-jsons.yaml`, modify the `generate-json` job starting at line 10 by inserting the `permissions` block after the job name line and before `timeout-minutes: 15`. No imports or additional methods are needed because this is a pure workflow-configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
